### PR TITLE
Disable shell access for system accounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:10-alpine
 
+RUN apk add shadow --no-cache
 RUN apk upgrade --no-cache
+
+RUN usermod -s /sbin/nologin operator
+RUN usermod -s /sbin/nologin postgres
+RUN usermod -s /sbin/nologin node
 
 RUN addgroup -S app
 RUN adduser -S app -G app -u 999 -h /app/


### PR DESCRIPTION
Per item HOFF-221-5-9 of the ITHC report.

Note: `shadow` is required to expose the `usermod` command on Alpine images.